### PR TITLE
date-field docs fix

### DIFF
--- a/src/docs/configuration/date-field.md
+++ b/src/docs/configuration/date-field.md
@@ -23,7 +23,7 @@ A simple example for a date that must be be December 24, 2023 or after:
   label: Creation date
   type: date
   options:
-    format: dd-MM-yyyy
+    format: yyyy-MM-dd
     min: 2023-12-24 # Must be on or after December 24, 2023. Notice it uses the format defined above.
 ```
 


### PR DESCRIPTION
The option states it uses the date format but the min example date was incorrect.